### PR TITLE
Allow configuration of Cognito endpoints

### DIFF
--- a/pkg/pennsieve/authentication_test.go
+++ b/pkg/pennsieve/authentication_test.go
@@ -1,1 +1,157 @@
 package pennsieve
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider"
+	"github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider/types"
+	"github.com/pennsieve/pennsieve-go/pkg/pennsieve/models/authentication"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+type AuthenticationServiceTestSuite struct {
+	suite.Suite
+	MockPennsieveServer
+	// Not using MockCognitoServer since we want to add assertions
+	// in this suite
+	MockCognito MockServer
+	TestClient  *Client
+	TestService AuthenticationService
+}
+
+var expectedCognitoConfig = authentication.CognitoConfig{
+	Region: "us-east-1",
+	UserPool: authentication.UserPool{
+		Region:      "us-east-1",
+		ID:          "auth-test-user-pool-id",
+		AppClientID: "auth-test-user-pool-app-client-id",
+	},
+	TokenPool: authentication.TokenPool{
+		Region:      "us-east-1",
+		AppClientID: "authTestTokenPoolAppClientId",
+	},
+	IdentityPool: authentication.IdentityPool{
+		Region: "us-east-1",
+		ID:     "auth-test-identity-pool-id",
+	}}
+
+func (s *AuthenticationServiceTestSuite) SetupTest() {
+	cognitoMux := http.NewServeMux()
+	cognitoServer := httptest.NewServer(cognitoMux)
+	s.MockCognito = MockServer{
+		Server: cognitoServer,
+		Mux:    cognitoMux,
+	}
+	s.MockPennsieveServer = NewMockPennsieveServer(s.T(), expectedCognitoConfig)
+	s.TestClient = NewClient(
+		APIParams{ApiHost: s.Server.URL},
+		&AWSCognitoEndpoints{IdentityProviderEndpoint: s.MockCognito.Server.URL})
+	s.TestService = s.TestClient.Authentication
+}
+
+func (s *AuthenticationServiceTestSuite) TearDownTest() {
+	s.MockCognito.Close()
+	s.MockPennsieveServer.Close()
+}
+
+func (s *AuthenticationServiceTestSuite) TestGetCognitoConfig() {
+	actualConfig, err := s.TestService.getCognitoConfig()
+	if s.NoError(err) {
+		s.Equal(expectedCognitoConfig, *actualConfig)
+	}
+}
+
+func (s *AuthenticationServiceTestSuite) TestAuthenticate() {
+	expectedApiKey := "api-key"
+	expectedApiSecret := "api-secret"
+
+	expectedAccessToken := "auth-test-access-token"
+	expectedRefreshToken := "auth-test-refresh-token"
+	expectedOrgNodeId := "N:organization:a9b8c7"
+	expectedOrgId := "456"
+	expectedIdToken := NewTestJWT(s.T(), expectedOrgNodeId, expectedOrgId, time.Hour)
+
+	s.MockCognito.Mux.HandleFunc("/", func(writer http.ResponseWriter, request *http.Request) {
+		s.Equal("POST", request.Method, "unexpected http method for cognito authenticate")
+		reqMap := map[string]any{}
+		if s.NoError(json.NewDecoder(request.Body).Decode(&reqMap)) {
+			s.Equal(types.AuthFlowTypeUserPasswordAuth, types.AuthFlowType(reqMap["AuthFlow"].(string)))
+			s.Equal(expectedCognitoConfig.TokenPool.AppClientID, reqMap["ClientId"])
+			authParams := reqMap["AuthParameters"].(map[string]any)
+			s.Equal(expectedApiKey, authParams["USERNAME"])
+			s.Equal(expectedApiSecret, authParams["PASSWORD"])
+		}
+		authenticationResult := types.AuthenticationResultType{
+			AccessToken:  &expectedAccessToken,
+			IdToken:      &expectedIdToken,
+			RefreshToken: &expectedRefreshToken,
+		}
+		respObj := cognitoidentityprovider.InitiateAuthOutput{
+			AuthenticationResult: &authenticationResult,
+		}
+		respBytes, err := json.Marshal(respObj)
+		if s.NoError(err) {
+			_, err = writer.Write(respBytes)
+			s.NoError(err)
+		}
+	})
+
+	actualSession, err := s.TestService.Authenticate(expectedApiKey, expectedApiSecret)
+	if s.Nil(err) {
+		s.Equal(expectedAccessToken, actualSession.Token)
+		s.Equal(expectedIdToken, actualSession.IdToken)
+		s.Equal(expectedRefreshToken, actualSession.RefreshToken)
+		s.True(actualSession.Expiration.After(time.Now()))
+	}
+
+	s.Equal(expectedOrgNodeId, s.TestClient.OrganizationNodeId)
+	s.Equal(expectedOrgId, fmt.Sprint(s.TestClient.OrganizationId))
+	s.Equal(*actualSession, s.TestClient.APISession)
+
+}
+
+func TestAuthenticationServiceSuite(t *testing.T) {
+	suite.Run(t, new(AuthenticationServiceTestSuite))
+}
+
+// Tests that in default deployment case we are not introducing a custom
+// endpoint resolver for AWS
+func TestProdEndpointResolver(t *testing.T) {
+	client := noOpPennsieveClient{}
+	service := NewAuthenticationService(client, "https://example.com", nil)
+	//goland:noinspection GoDeprecation
+	assert.Nil(t, (*service).awsConfig.EndpointResolver)
+	assert.Nil(t, (*service).awsConfig.EndpointResolverWithOptions)
+}
+
+type noOpPennsieveClient struct{}
+
+func (noOpPennsieveClient) sendUnauthenticatedRequest(ctx context.Context, req *http.Request, v interface{}) error {
+	panic("implement me")
+}
+
+func (noOpPennsieveClient) sendRequest(ctx context.Context, req *http.Request, v interface{}) error {
+	panic("implement me")
+}
+
+func (noOpPennsieveClient) GetAPIParams() *APIParams {
+	panic("implement me")
+}
+
+func (noOpPennsieveClient) SetSession(s APISession) {
+	panic("implement me")
+}
+
+func (noOpPennsieveClient) SetOrganization(orgId int, orgNodeId string) {
+	panic("implement me")
+}
+
+func (noOpPennsieveClient) Updateparams(params APIParams) {
+	panic("implement me")
+}

--- a/pkg/pennsieve/authentication_test.go
+++ b/pkg/pennsieve/authentication_test.go
@@ -103,7 +103,7 @@ func (s *AuthenticationServiceTestSuite) TestAuthenticate() {
 	})
 
 	actualSession, err := s.TestService.Authenticate(expectedApiKey, expectedApiSecret)
-	if s.Nil(err) {
+	if s.NoError(err) {
 		s.Equal(expectedAccessToken, actualSession.Token)
 		s.Equal(expectedIdToken, actualSession.IdToken)
 		s.Equal(expectedRefreshToken, actualSession.RefreshToken)

--- a/pkg/pennsieve/client.go
+++ b/pkg/pennsieve/client.go
@@ -56,7 +56,7 @@ type Client struct {
 }
 
 // NewClient creates a new Pennsieve HTTP client.
-func NewClient(params APIParams, cognitoIdentityProviderEndpoint string) *Client {
+func NewClient(params APIParams, awsCognitoEndpoints *AWSCognitoEndpoints) *Client {
 
 	c := &Client{
 		APISession:         APISession{},
@@ -66,7 +66,7 @@ func NewClient(params APIParams, cognitoIdentityProviderEndpoint string) *Client
 		OrganizationId:     0,
 	}
 
-	c.Authentication = NewAuthenticationService(c, params.ApiHost, cognitoIdentityProviderEndpoint)
+	c.Authentication = NewAuthenticationService(c, params.ApiHost, awsCognitoEndpoints)
 	c.Organization = NewOrganizationService(c, params.ApiHost)
 	c.User = NewUserService(c, params.ApiHost)
 	c.Dataset = NewDatasetService(c, params.ApiHost)

--- a/pkg/pennsieve/client.go
+++ b/pkg/pennsieve/client.go
@@ -56,7 +56,7 @@ type Client struct {
 }
 
 // NewClient creates a new Pennsieve HTTP client.
-func NewClient(params APIParams) *Client {
+func NewClient(params APIParams, cognitoIdentityProviderEndpoint string) *Client {
 
 	c := &Client{
 		APISession:         APISession{},
@@ -66,7 +66,7 @@ func NewClient(params APIParams) *Client {
 		OrganizationId:     0,
 	}
 
-	c.Authentication = NewAuthenticationService(c, params.ApiHost)
+	c.Authentication = NewAuthenticationService(c, params.ApiHost, cognitoIdentityProviderEndpoint)
 	c.Organization = NewOrganizationService(c, params.ApiHost)
 	c.User = NewUserService(c, params.ApiHost)
 	c.Dataset = NewDatasetService(c, params.ApiHost)

--- a/pkg/pennsieve/dataset_test.go
+++ b/pkg/pennsieve/dataset_test.go
@@ -4,111 +4,93 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider"
-	"github.com/golang-jwt/jwt"
-	"github.com/pennsieve/pennsieve-go/pkg/pennsieve/models/authentication"
 	"github.com/pennsieve/pennsieve-go/pkg/pennsieve/models/dataset"
 	"github.com/stretchr/testify/suite"
 	"net/http"
-	"net/http/httptest"
 	"testing"
-	"time"
 )
 
-type ServerTestSuite struct {
+type DatasetServiceTestSuite struct {
 	suite.Suite
-	Server        *httptest.Server
-	Mux           *http.ServeMux
-	CognitoServer *httptest.Server
+	MockPennsieveServer
+	MockCognitoServer
+	TestService DatasetService
 }
 
-func (s *ServerTestSuite) SetupTest() {
-	s.Mux = http.NewServeMux()
-	s.Server = httptest.NewServer(s.Mux)
-	s.Mux.HandleFunc("/authentication/cognito-config", func(writer http.ResponseWriter, request *http.Request) {
-		cognitoConfig := authentication.CognitoConfig{
-			Region: "us-east-1",
-			UserPool: authentication.UserPool{
-				Region:      "us-east-1",
-				ID:          "mock-user-pool-id",
-				AppClientID: "mock-user-pool-app-client-id",
-			},
-			TokenPool: authentication.TokenPool{
-				Region:      "us-east-1",
-				AppClientID: "mockTokenPoolAppClientId",
-			},
-			IdentityPool: authentication.IdentityPool{
-				Region: "us-east-1",
-				ID:     "mock-identity-pool-id",
-			},
-		}
-		body, err := json.Marshal(cognitoConfig)
-		if err != nil {
-			s.FailNow("could not marshal mock CognitoConfig")
-		}
-		writer.Write(body)
-	})
-
-	s.CognitoServer = httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
-		if request.URL.String() != "/" {
-			s.FailNowf("unexpected cognito identity provider call", "expected: %q, got: %q", "/", request.URL)
-		}
-		body := request.Body
-		defer body.Close()
-		requestPayload := cognitoidentityprovider.InitiateAuthInput{}
-		decodeError := json.NewDecoder(body).Decode(&requestPayload)
-		if decodeError != nil {
-			s.FailNow("failed to decode cognito input: %s", decodeError)
-		}
-		fmt.Println(requestPayload)
-		idToken := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
-			"custom:organization_node_id": "N:Organization:abcd",
-			"custom:organization_id":      "9999",
-			"exp":                         time.Now().Add(time.Hour).Unix(),
-		})
-
-		idTokenString, err := idToken.SignedString([]byte("test-signing-key"))
-		if err != nil {
-			s.FailNowf("error getting signed string from JWT token", "%s", err)
-		}
-		fmt.Fprintf(writer, `{"AuthenticationResult": {"AccessToken": %q, "ExpiresIn": 3600, "IdToken": %q, "RefreshToken": %q, "TokenType": "Bearer"}, "ChallengeParameters": {}}`,
-			"mock-access-token",
-			idTokenString,
-			"mock-refresh-token")
-	}))
-
+func (s *DatasetServiceTestSuite) SetupTest() {
+	s.MockCognitoServer = NewMockCognitoServerDefault(s.T())
+	s.MockPennsieveServer = NewMockPennsieveServerDefault(s.T())
+	client := NewClient(APIParams{
+		ApiHost: s.Server.URL,
+	}, s.IdProviderServer.URL)
+	s.TestService = client.Dataset
 }
 
-func (s *ServerTestSuite) TeardownTest() {
-	s.Server.Close()
-	s.CognitoServer.Close()
+func (s *DatasetServiceTestSuite) TearDownTest() {
+	s.MockPennsieveServer.Close()
+	s.MockCognitoServer.Close()
 }
 
-func (s *ServerTestSuite) TestGetDataset() {
+func (s *DatasetServiceTestSuite) TestGetDataset() {
 	expectedDatasetId := "N:Dataset:1234"
 	expectedDatasetName := "Test Dataset"
 	expectedPath := "/datasets/" + expectedDatasetId
 	s.Mux.HandleFunc(expectedPath, func(writer http.ResponseWriter, request *http.Request) {
+		s.Equalf("GET", request.Method, "expected method GET, got: %q", request.Method)
 		datasetResponse := dataset.GetDatasetResponse{Content: dataset.Content{Name: expectedDatasetName}}
 		body, err := json.Marshal(datasetResponse)
-		if err != nil {
-			s.FailNow("error marshalling GetDatasetResponse")
+		if s.NoError(err) {
+			writer.Write(body)
 		}
-		writer.Write(body)
-
 	})
-	s.Mux.HandleFunc("/", func(writer http.ResponseWriter, request *http.Request) {
-		s.FailNowf("unexpected request", "got %s, expected %s", request.URL, expectedPath)
-	})
-	client := NewClient(APIParams{
-		ApiHost: s.Server.URL,
-	}, s.CognitoServer.URL)
 
-	testDatasetService := client.Dataset
-	dataset, _ := testDatasetService.Get(context.Background(), expectedDatasetId)
-	s.Equal(expectedDatasetName, dataset.Content.Name, "Dataset name must match.")
+	dataset, err := s.TestService.Get(context.Background(), expectedDatasetId)
+	if s.NoError(err) {
+		s.Equal(expectedDatasetName, dataset.Content.Name, "unexpected name")
+	}
 }
 
-func TestDatasetSuite(t *testing.T) {
-	suite.Run(t, new(ServerTestSuite))
+func (s *DatasetServiceTestSuite) TestCreateDataset() {
+	expectedName := "created dataset"
+	expectedDescription := "testing create dataset"
+	expectedTags := []string{"tag one", "tag-2"}
+	expectedTagString := fmt.Sprintf("[%q, %q]", expectedTags[0], expectedTags[1])
+	s.Mux.HandleFunc("/datasets/", func(writer http.ResponseWriter, request *http.Request) {
+		s.Equalf("POST", request.Method, "expected method POST, got: %q", request.Method)
+		requestBody := struct {
+			Name        string
+			Description string
+			Tags        []string
+		}{}
+		err := json.NewDecoder(request.Body).Decode(&requestBody)
+		if err != nil {
+			request.Body.Close()
+			s.Fail("error decoding create body request", err)
+		}
+		s.Equal(expectedName, requestBody.Name, "unexpected name in request body")
+		s.Equal(expectedDescription, requestBody.Description, "unexpected description in request body")
+		s.Equal(expectedTags, requestBody.Tags, "unexpected tags in request body")
+		resp := dataset.CreateDatasetResponse{
+			Content: dataset.Content{
+				Name:        expectedName,
+				Description: expectedDescription,
+				Tags:        expectedTags,
+			},
+		}
+		respBody, err := json.Marshal(resp)
+		if s.NoError(err) {
+			writer.Write(respBody)
+
+		}
+	})
+	resp, err := s.TestService.Create(context.Background(), expectedName, expectedDescription, expectedTagString)
+	if s.NoError(err) {
+		s.Equal(expectedName, resp.Content.Name, "unexpected name")
+		s.Equal(expectedDescription, resp.Content.Description, "unexpected description")
+		s.Equal(expectedTags, resp.Content.Tags, "unexpected tags")
+	}
+}
+
+func TestDatasetServiceSuite(t *testing.T) {
+	suite.Run(t, new(DatasetServiceTestSuite))
 }

--- a/pkg/pennsieve/dataset_test.go
+++ b/pkg/pennsieve/dataset_test.go
@@ -2,20 +2,113 @@ package pennsieve
 
 import (
 	"context"
-	"github.com/stretchr/testify/assert"
+	"encoding/json"
+	"fmt"
+	"github.com/aws/aws-sdk-go-v2/service/cognitoidentityprovider"
+	"github.com/golang-jwt/jwt"
+	"github.com/pennsieve/pennsieve-go/pkg/pennsieve/models/authentication"
+	"github.com/pennsieve/pennsieve-go/pkg/pennsieve/models/dataset"
+	"github.com/stretchr/testify/suite"
+	"net/http"
+	"net/http/httptest"
 	"testing"
+	"time"
 )
 
-func TestGetDataset(t *testing.T) {
+type ServerTestSuite struct {
+	suite.Suite
+	Server        *httptest.Server
+	Mux           *http.ServeMux
+	CognitoServer *httptest.Server
+}
 
-	ht := mockHTTPClient{
-		APISession:         APISession{},
-		APICredentials:     APICredentials{},
-		OrganizationNodeId: "",
-		OrganizationId:     0,
-	}
+func (s *ServerTestSuite) SetupTest() {
+	s.Mux = http.NewServeMux()
+	s.Server = httptest.NewServer(s.Mux)
+	s.Mux.HandleFunc("/authentication/cognito-config", func(writer http.ResponseWriter, request *http.Request) {
+		cognitoConfig := authentication.CognitoConfig{
+			Region: "us-east-1",
+			UserPool: authentication.UserPool{
+				Region:      "us-east-1",
+				ID:          "mock-user-pool-id",
+				AppClientID: "mock-user-pool-app-client-id",
+			},
+			TokenPool: authentication.TokenPool{
+				Region:      "us-east-1",
+				AppClientID: "mockTokenPoolAppClientId",
+			},
+			IdentityPool: authentication.IdentityPool{
+				Region: "us-east-1",
+				ID:     "mock-identity-pool-id",
+			},
+		}
+		body, err := json.Marshal(cognitoConfig)
+		if err != nil {
+			s.FailNow("could not marshal mock CognitoConfig")
+		}
+		writer.Write(body)
+	})
 
-	testDatasetService := NewDatasetService(&ht, "https://test.com")
-	dataset, _ := testDatasetService.Get(context.Background(), "N:Dataset:1234")
-	assert.Equal(t, "Test Dataset", dataset.Content.Name, "Org name must match.")
+	s.CognitoServer = httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.URL.String() != "/" {
+			s.FailNowf("unexpected cognito identity provider call", "expected: %q, got: %q", "/", request.URL)
+		}
+		body := request.Body
+		defer body.Close()
+		requestPayload := cognitoidentityprovider.InitiateAuthInput{}
+		decodeError := json.NewDecoder(body).Decode(&requestPayload)
+		if decodeError != nil {
+			s.FailNow("failed to decode cognito input: %s", decodeError)
+		}
+		fmt.Println(requestPayload)
+		idToken := jwt.NewWithClaims(jwt.SigningMethodHS256, jwt.MapClaims{
+			"custom:organization_node_id": "N:Organization:abcd",
+			"custom:organization_id":      "9999",
+			"exp":                         time.Now().Add(time.Hour).Unix(),
+		})
+
+		idTokenString, err := idToken.SignedString([]byte("test-signing-key"))
+		if err != nil {
+			s.FailNowf("error getting signed string from JWT token", "%s", err)
+		}
+		fmt.Fprintf(writer, `{"AuthenticationResult": {"AccessToken": %q, "ExpiresIn": 3600, "IdToken": %q, "RefreshToken": %q, "TokenType": "Bearer"}, "ChallengeParameters": {}}`,
+			"mock-access-token",
+			idTokenString,
+			"mock-refresh-token")
+	}))
+
+}
+
+func (s *ServerTestSuite) TeardownTest() {
+	s.Server.Close()
+	s.CognitoServer.Close()
+}
+
+func (s *ServerTestSuite) TestGetDataset() {
+	expectedDatasetId := "N:Dataset:1234"
+	expectedDatasetName := "Test Dataset"
+	expectedPath := "/datasets/" + expectedDatasetId
+	s.Mux.HandleFunc(expectedPath, func(writer http.ResponseWriter, request *http.Request) {
+		datasetResponse := dataset.GetDatasetResponse{Content: dataset.Content{Name: expectedDatasetName}}
+		body, err := json.Marshal(datasetResponse)
+		if err != nil {
+			s.FailNow("error marshalling GetDatasetResponse")
+		}
+		writer.Write(body)
+
+	})
+	s.Mux.HandleFunc("/", func(writer http.ResponseWriter, request *http.Request) {
+		s.FailNowf("unexpected request", "got %s, expected %s", request.URL, expectedPath)
+	})
+	client := NewClient(APIParams{
+		ApiHost: s.Server.URL,
+	}, s.CognitoServer.URL)
+
+	testDatasetService := client.Dataset
+	dataset, _ := testDatasetService.Get(context.Background(), expectedDatasetId)
+	s.Equal(expectedDatasetName, dataset.Content.Name, "Dataset name must match.")
+}
+
+func TestDatasetSuite(t *testing.T) {
+	suite.Run(t, new(ServerTestSuite))
 }

--- a/pkg/pennsieve/manifest_test.go
+++ b/pkg/pennsieve/manifest_test.go
@@ -2,21 +2,60 @@ package pennsieve
 
 import (
 	"context"
+	"encoding/json"
 	"github.com/pennsieve/pennsieve-go-api/pkg/models/manifest"
-	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+	"net/http"
 	"testing"
 )
 
-func TestCreateManifest(t *testing.T) {
+type ManifestServiceTestSuite struct {
+	suite.Suite
+	MockCognitoServer
+	APIServer   MockPennsieveServer
+	API2Server  MockPennsieveServer
+	TestService ManifestService
+}
 
-	client := NewClient(APIParams{}, "")
+func (s *ManifestServiceTestSuite) SetupTest() {
+	s.MockCognitoServer = NewMockCognitoServerDefault(s.T())
+	s.APIServer = NewMockPennsieveServerDefault(s.T())
+	s.API2Server = NewMockPennsieveServerDefault(s.T())
+	client := NewClient(APIParams{
+		ApiHost:  s.APIServer.Server.URL,
+		ApiHost2: s.API2Server.Server.URL,
+	}, s.IdProviderServer.URL)
+	s.TestService = client.Manifest
+}
 
-	testManifestService := client.Manifest
-	manifest, _ := testManifestService.Create(context.Background(), manifest.DTO{
-		ID:        "",
-		DatasetId: "",
+func (s *ManifestServiceTestSuite) TearDownTest() {
+	s.MockCognitoServer.Close()
+	s.APIServer.Close()
+	s.API2Server.Close()
+}
+
+func (s *ManifestServiceTestSuite) TestCreateManifest() {
+	expectedNodeId := "1234"
+	expectedDatasetId := "N:Dataset:1a2b"
+	s.API2Server.Mux.HandleFunc("/manifest/", func(writer http.ResponseWriter, request *http.Request) {
+		s.Equal("POST", request.Method, "unexpected http method for Create Manifest")
+		respObj := manifest.PostResponse{
+			ManifestNodeId: expectedNodeId,
+		}
+		respBody, err := json.Marshal(respObj)
+		if s.NoError(err) {
+			writer.Write(respBody)
+		}
+	})
+	manifest, _ := s.TestService.Create(context.Background(), manifest.DTO{
+		ID:        expectedNodeId,
+		DatasetId: expectedDatasetId,
 		Files:     nil,
 		Status:    0,
 	})
-	assert.Equal(t, "1234", manifest.ManifestNodeId, "Manifest ID name must match.")
+	s.Equal(expectedNodeId, manifest.ManifestNodeId, "unexpected manifest node id")
+}
+
+func TestManifestService(t *testing.T) {
+	suite.Run(t, new(ManifestServiceTestSuite))
 }

--- a/pkg/pennsieve/manifest_test.go
+++ b/pkg/pennsieve/manifest_test.go
@@ -9,14 +9,9 @@ import (
 
 func TestCreateManifest(t *testing.T) {
 
-	ht := mockHTTPClient{
-		APISession:         APISession{},
-		APICredentials:     APICredentials{},
-		OrganizationNodeId: "",
-		OrganizationId:     0,
-	}
+	client := NewClient(APIParams{}, "")
 
-	testManifestService := NewManifestService(&ht, "https://test.com")
+	testManifestService := client.Manifest
 	manifest, _ := testManifestService.Create(context.Background(), manifest.DTO{
 		ID:        "",
 		DatasetId: "",

--- a/pkg/pennsieve/organization.go
+++ b/pkg/pennsieve/organization.go
@@ -28,7 +28,7 @@ func NewOrganizationService(client PennsieveHTTPClient, baseUrl string) *organiz
 // List lists all the organizations that the user belongs to.
 func (o *organizationService) List(ctx context.Context) (*organization.GetOrganizationsResponse, error) {
 
-	req, err := http.NewRequest("GET", fmt.Sprintf("%s/organizatinons", o.baseUrl), nil)
+	req, err := http.NewRequest("GET", fmt.Sprintf("%s/organizations", o.baseUrl), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/pennsieve/organization_test.go
+++ b/pkg/pennsieve/organization_test.go
@@ -19,7 +19,9 @@ type OrganizationServiceTestSuite struct {
 func (s *OrganizationServiceTestSuite) SetupTest() {
 	s.MockCognitoServer = NewMockCognitoServerDefault(s.T())
 	s.MockPennsieveServer = NewMockPennsieveServerDefault(s.T())
-	client := NewClient(APIParams{ApiHost: s.Server.URL}, s.IdProviderServer.URL)
+	client := NewClient(
+		APIParams{ApiHost: s.Server.URL},
+		&AWSCognitoEndpoints{IdentityProviderEndpoint: s.IdProviderServer.URL})
 	s.TestService = client.Organization
 }
 
@@ -41,7 +43,8 @@ func (s *OrganizationServiceTestSuite) TestGetOrg() {
 		}
 		respBody, err := json.Marshal(respOrg)
 		if s.NoError(err) {
-			writer.Write(respBody)
+			_, err := writer.Write(respBody)
+			s.NoError(err)
 		}
 	})
 	org, err := s.TestService.Get(context.Background(), expectedOrgId)
@@ -70,7 +73,8 @@ func (s *OrganizationServiceTestSuite) TestList() {
 		}
 		respBody, err := json.Marshal(respList)
 		if s.NoError(err) {
-			writer.Write(respBody)
+			_, err := writer.Write(respBody)
+			s.NoError(err)
 		}
 	})
 

--- a/pkg/pennsieve/organization_test.go
+++ b/pkg/pennsieve/organization_test.go
@@ -10,28 +10,16 @@ import (
 // We mock the HTTP-client to return a user.
 func TestGetOrg(t *testing.T) {
 
-	ht := mockHTTPClient{
-		APISession:         APISession{},
-		APICredentials:     APICredentials{},
-		OrganizationNodeId: "",
-		OrganizationId:     0,
-	}
-
-	testOrganizationService := NewOrganizationService(&ht, "https://test.com")
+	client := NewClient(APIParams{}, "")
+	testOrganizationService := client.Organization
 	org, _ := testOrganizationService.Get(context.Background(), "N:org:1234")
 	assert.Equal(t, "Valid Organization", org.Organization.Name, "Org name must match.")
 }
 
 func TestList(t *testing.T) {
 
-	mockClient := mockHTTPClient{
-		APISession:         APISession{},
-		APICredentials:     APICredentials{},
-		OrganizationNodeId: "",
-		OrganizationId:     0,
-	}
-
-	testOrganizationService := NewOrganizationService(&mockClient, "https://test.com")
+	client := NewClient(APIParams{}, "")
+	testOrganizationService := client.Organization
 	org, _ := testOrganizationService.List(context.Background())
 
 	assert.Equal(t, "First Org", org.Organizations[0].Organization.Name, "Org name must match.")

--- a/pkg/pennsieve/organization_test.go
+++ b/pkg/pennsieve/organization_test.go
@@ -2,27 +2,86 @@ package pennsieve
 
 import (
 	"context"
-	"github.com/stretchr/testify/assert"
+	"encoding/json"
+	"github.com/pennsieve/pennsieve-go/pkg/pennsieve/models/organization"
+	"github.com/stretchr/testify/suite"
+	"net/http"
 	"testing"
 )
 
-// Testing very basic component of UserService to get active user.
-// We mock the HTTP-client to return a user.
-func TestGetOrg(t *testing.T) {
-
-	client := NewClient(APIParams{}, "")
-	testOrganizationService := client.Organization
-	org, _ := testOrganizationService.Get(context.Background(), "N:org:1234")
-	assert.Equal(t, "Valid Organization", org.Organization.Name, "Org name must match.")
+type OrganizationServiceTestSuite struct {
+	suite.Suite
+	MockCognitoServer
+	MockPennsieveServer
+	TestService OrganizationService
 }
 
-func TestList(t *testing.T) {
+func (s *OrganizationServiceTestSuite) SetupTest() {
+	s.MockCognitoServer = NewMockCognitoServerDefault(s.T())
+	s.MockPennsieveServer = NewMockPennsieveServerDefault(s.T())
+	client := NewClient(APIParams{ApiHost: s.Server.URL}, s.IdProviderServer.URL)
+	s.TestService = client.Organization
+}
 
-	client := NewClient(APIParams{}, "")
-	testOrganizationService := client.Organization
-	org, _ := testOrganizationService.List(context.Background())
+func (s *OrganizationServiceTestSuite) TearDownTest() {
+	s.MockCognitoServer.Close()
+	s.MockPennsieveServer.Close()
+}
 
-	assert.Equal(t, "First Org", org.Organizations[0].Organization.Name, "Org name must match.")
-	assert.Equal(t, "Second Org", org.Organizations[1].Organization.Name, "Org name must match.")
+// Testing very basic component of UserService to get active user.
+func (s *OrganizationServiceTestSuite) TestGetOrg() {
+	expectedOrgId := "N:org:1234"
+	expectedOrgName := "Valid Organization"
+	s.Mux.HandleFunc("/organizations/"+expectedOrgId, func(writer http.ResponseWriter, request *http.Request) {
+		s.Equal("GET", request.Method, "unexpected http method for GetOrg")
+		respOrg := organization.GetOrganizationResponse{
+			Organization: organization.Organization{
+				ID:   expectedOrgId,
+				Name: expectedOrgName},
+		}
+		respBody, err := json.Marshal(respOrg)
+		if s.NoError(err) {
+			writer.Write(respBody)
+		}
+	})
+	org, err := s.TestService.Get(context.Background(), expectedOrgId)
+	if s.NoError(err) {
+		s.Equal(expectedOrgId, org.Organization.ID, "unexpected org id")
+		s.Equal(expectedOrgName, org.Organization.Name, "unexpected org name")
+	}
+}
 
+func (s *OrganizationServiceTestSuite) TestList() {
+	expectedOrg1 := organization.Organization{
+		ID:   "N:org:1234",
+		Name: "First Org",
+	}
+	expectedOrg2 := organization.Organization{
+		ID:   "N:org:abcd",
+		Name: "Second Org",
+	}
+	s.Mux.HandleFunc("/organizations/", func(writer http.ResponseWriter, request *http.Request) {
+		s.Equal("GET", request.Method, "unexpected http method for List")
+		respList := organization.GetOrganizationsResponse{
+			Organizations: []organization.Organizations{
+				{Organization: expectedOrg1},
+				{Organization: expectedOrg2},
+			},
+		}
+		respBody, err := json.Marshal(respList)
+		if s.NoError(err) {
+			writer.Write(respBody)
+		}
+	})
+
+	org, err := s.TestService.List(context.Background())
+	if s.NoError(err) {
+		s.Len(org.Organizations, 2)
+		s.Equal(expectedOrg1, org.Organizations[0].Organization)
+		s.Equal(expectedOrg2, org.Organizations[1].Organization)
+	}
+}
+
+func TestOrganizationService(t *testing.T) {
+	suite.Run(t, new(OrganizationServiceTestSuite))
 }

--- a/pkg/pennsieve/pennsieve_test.go
+++ b/pkg/pennsieve/pennsieve_test.go
@@ -11,11 +11,25 @@ import (
 	"time"
 )
 
+// This file contains httptest.Servers wrapped for convenience to be used as mocks for
+// both AWS' Cognito Identity Provider and Pennsieve API servers.
+// It's probably not idiomatic to have these here
+
+// A httptest.Server that mocks Amazon CognitoIdentityProvider
+// Create with NewMockCognitoServer*() to get one with the correct handler already in place.
 type MockCognitoServer struct {
-	IdProviderServer *httptest.Server
+	IdProviderServer   *httptest.Server
+	OrganizationNodeId string
 }
 
-func NewMockCognitoServer(t *testing.T, expectedClaims jwt.MapClaims) MockCognitoServer {
+const (
+	OrgNodeIdClaimKey = "custom:organization_node_id"
+	OrgIdClaimKey     = "custom:organization_id"
+)
+
+// Returns a MockCognitoServer configured to always return an unexpired IDToken JWT that includes the claims made in expectedClaims.
+// If expectedClaims is nil, the returned claims will be as in NewMockCognitoServerDefault()
+func NewMockCognitoServer(t *testing.T, expectedClaims map[string]any) MockCognitoServer {
 	if expectedClaims == nil {
 		return NewMockCognitoServerDefault(t)
 	}
@@ -23,26 +37,40 @@ func NewMockCognitoServer(t *testing.T, expectedClaims jwt.MapClaims) MockCognit
 		if request.URL.String() != "/" {
 			t.Errorf("unexpected cognito identity provider call: expected: %q, got: %q", "/", request.URL)
 		}
-		idToken := jwt.NewWithClaims(jwt.SigningMethodHS256, expectedClaims)
+		claims := jwt.MapClaims{
+			"exp": time.Now().Add(time.Hour).Unix(),
+		}
+		for k, v := range expectedClaims {
+			claims[k] = v
+		}
+		idToken := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
 
 		idTokenString, err := idToken.SignedString([]byte("test-signing-key"))
 		if err != nil {
 			t.Errorf("error getting signed string from JWT token: %s", err)
 		}
-		fmt.Fprintf(writer, `{"AuthenticationResult": {"AccessToken": %q, "ExpiresIn": 3600, "IdToken": %q, "RefreshToken": %q, "TokenType": "Bearer"}, "ChallengeParameters": {}}`,
+		_, err = fmt.Fprintf(writer, `{"AuthenticationResult": {"AccessToken": %q, "ExpiresIn": 3600, "IdToken": %q, "RefreshToken": %q, "TokenType": "Bearer"}, "ChallengeParameters": {}}`,
 			"mock-access-token",
 			idTokenString,
 			"mock-refresh-token")
+		if err != nil {
+			t.Error("error writing AuthenticationResult")
+		}
 	}))
 
-	return MockCognitoServer{IdProviderServer: cognitoServer}
+	server := MockCognitoServer{IdProviderServer: cognitoServer}
+	if orgNodeId, ok := expectedClaims[OrgNodeIdClaimKey]; ok {
+		server.OrganizationNodeId = orgNodeId.(string)
+	}
+	return server
 }
 
+// Returns a MockCognitoServer configured to always return a JWT IdToken that includes org node id and org id claims.
+// Also, an exp claim with a time an hour in the future.
 func NewMockCognitoServerDefault(t *testing.T) MockCognitoServer {
-	return NewMockCognitoServer(t, jwt.MapClaims{
-		"custom:organization_node_id": "N:Organization:abcd",
-		"custom:organization_id":      "9999",
-		"exp":                         time.Now().Add(time.Hour).Unix(),
+	return NewMockCognitoServer(t, map[string]any{
+		OrgNodeIdClaimKey: "N:Organization:abcd",
+		OrgIdClaimKey:     "9999",
 	})
 }
 
@@ -50,11 +78,15 @@ func (m *MockCognitoServer) Close() {
 	m.IdProviderServer.Close()
 }
 
+// A httptest.Server intended to mock a Pennsieve API server.
+// In tests, Handlers should be added to Mux.
 type MockPennsieveServer struct {
 	Server *httptest.Server
 	Mux    *http.ServeMux
 }
 
+// Returns a MockPennsieveServer with the same configuration as
+// NewMockPennsieveServer() with a default authentication.CognitoConfig
 func NewMockPennsieveServerDefault(t *testing.T) MockPennsieveServer {
 	return NewMockPennsieveServer(t, authentication.CognitoConfig{
 		Region: "us-east-1",
@@ -73,6 +105,9 @@ func NewMockPennsieveServerDefault(t *testing.T) MockPennsieveServer {
 		}})
 }
 
+// Returns a MockPennsieveServer with a GET "/authentication/cognito-config" handler already configured. It will return the given
+// expectedCognitoConfig. If you don't care about the content of the CognitoConfig you can use NewMockPennsieveServerDefault() instead.
+// There is also a "/" handler configured that always fails the test to catch any unexpected requests.
 func NewMockPennsieveServer(t *testing.T, expectedCognitoConfig authentication.CognitoConfig) MockPennsieveServer {
 	mux := http.NewServeMux()
 	server := httptest.NewServer(mux)
@@ -81,7 +116,10 @@ func NewMockPennsieveServer(t *testing.T, expectedCognitoConfig authentication.C
 		if err != nil {
 			t.Error("could not marshal mock CognitoConfig")
 		}
-		writer.Write(body)
+		_, err = writer.Write(body)
+		if err != nil {
+			t.Error("error writing CognitoConfig response")
+		}
 	})
 	mux.HandleFunc("/", func(writer http.ResponseWriter, request *http.Request) {
 		t.Errorf("Unhandled request: method: %q, path: %q. If this call is expected add a HandleFunc to MockPennsieveServer.Mux", request.Method, request.URL)

--- a/pkg/pennsieve/pennsieve_test.go
+++ b/pkg/pennsieve/pennsieve_test.go
@@ -1,0 +1,95 @@
+package pennsieve
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/golang-jwt/jwt"
+	"github.com/pennsieve/pennsieve-go/pkg/pennsieve/models/authentication"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+type MockCognitoServer struct {
+	IdProviderServer *httptest.Server
+}
+
+func NewMockCognitoServer(t *testing.T, expectedClaims jwt.MapClaims) MockCognitoServer {
+	if expectedClaims == nil {
+		return NewMockCognitoServerDefault(t)
+	}
+	cognitoServer := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.URL.String() != "/" {
+			t.Errorf("unexpected cognito identity provider call: expected: %q, got: %q", "/", request.URL)
+		}
+		idToken := jwt.NewWithClaims(jwt.SigningMethodHS256, expectedClaims)
+
+		idTokenString, err := idToken.SignedString([]byte("test-signing-key"))
+		if err != nil {
+			t.Errorf("error getting signed string from JWT token: %s", err)
+		}
+		fmt.Fprintf(writer, `{"AuthenticationResult": {"AccessToken": %q, "ExpiresIn": 3600, "IdToken": %q, "RefreshToken": %q, "TokenType": "Bearer"}, "ChallengeParameters": {}}`,
+			"mock-access-token",
+			idTokenString,
+			"mock-refresh-token")
+	}))
+
+	return MockCognitoServer{IdProviderServer: cognitoServer}
+}
+
+func NewMockCognitoServerDefault(t *testing.T) MockCognitoServer {
+	return NewMockCognitoServer(t, jwt.MapClaims{
+		"custom:organization_node_id": "N:Organization:abcd",
+		"custom:organization_id":      "9999",
+		"exp":                         time.Now().Add(time.Hour).Unix(),
+	})
+}
+
+func (m *MockCognitoServer) Close() {
+	m.IdProviderServer.Close()
+}
+
+type MockPennsieveServer struct {
+	Server *httptest.Server
+	Mux    *http.ServeMux
+}
+
+func NewMockPennsieveServerDefault(t *testing.T) MockPennsieveServer {
+	return NewMockPennsieveServer(t, authentication.CognitoConfig{
+		Region: "us-east-1",
+		UserPool: authentication.UserPool{
+			Region:      "us-east-1",
+			ID:          "mock-user-pool-id",
+			AppClientID: "mock-user-pool-app-client-id",
+		},
+		TokenPool: authentication.TokenPool{
+			Region:      "us-east-1",
+			AppClientID: "mockTokenPoolAppClientId",
+		},
+		IdentityPool: authentication.IdentityPool{
+			Region: "us-east-1",
+			ID:     "mock-identity-pool-id",
+		}})
+}
+
+func NewMockPennsieveServer(t *testing.T, expectedCognitoConfig authentication.CognitoConfig) MockPennsieveServer {
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	mux.HandleFunc("/authentication/cognito-config", func(writer http.ResponseWriter, request *http.Request) {
+		body, err := json.Marshal(expectedCognitoConfig)
+		if err != nil {
+			t.Error("could not marshal mock CognitoConfig")
+		}
+		writer.Write(body)
+	})
+	mux.HandleFunc("/", func(writer http.ResponseWriter, request *http.Request) {
+		t.Errorf("Unhandled request: method: %q, path: %q. If this call is expected add a HandleFunc to MockPennsieveServer.Mux", request.Method, request.URL)
+	})
+
+	return MockPennsieveServer{Server: server, Mux: mux}
+}
+
+func (m *MockPennsieveServer) Close() {
+	m.Server.Close()
+}

--- a/pkg/pennsieve/user_test.go
+++ b/pkg/pennsieve/user_test.go
@@ -10,14 +10,9 @@ import (
 // We mock the HTTP-client to return a user.
 func TestGetUser(t *testing.T) {
 
-	ht := mockHTTPClient{
-		APISession:         APISession{},
-		APICredentials:     APICredentials{},
-		OrganizationNodeId: "",
-		OrganizationId:     0,
-	}
+	client := NewClient(APIParams{}, "")
 
-	testUserService := NewUserService(&ht, "http://test.com")
+	testUserService := client.User
 
 	user, _ := testUserService.GetUser(context.Background())
 

--- a/pkg/pennsieve/user_test.go
+++ b/pkg/pennsieve/user_test.go
@@ -2,20 +2,55 @@ package pennsieve
 
 import (
 	"context"
-	"github.com/stretchr/testify/assert"
+	"encoding/json"
+	"github.com/pennsieve/pennsieve-go/pkg/pennsieve/models/user"
+	"github.com/stretchr/testify/suite"
+	"net/http"
 	"testing"
 )
 
+type UserServiceTestSuite struct {
+	suite.Suite
+	MockCognitoServer
+	MockPennsieveServer
+	TestService UserService
+}
+
+func (s *UserServiceTestSuite) SetupTest() {
+	s.MockCognitoServer = NewMockCognitoServerDefault(s.T())
+	s.MockPennsieveServer = NewMockPennsieveServerDefault(s.T())
+	client := NewClient(APIParams{
+		ApiHost: s.Server.URL,
+	}, s.IdProviderServer.URL)
+	s.TestService = client.User
+}
+
+func (s *UserServiceTestSuite) TearDownTest() {
+	s.MockCognitoServer.Close()
+	s.MockPennsieveServer.Close()
+}
+
 // Testing very basic component of UserService to get active user.
-// We mock the HTTP-client to return a user.
-func TestGetUser(t *testing.T) {
+func (s *UserServiceTestSuite) TestGetUser() {
+	expectedUserId := "1234"
+	s.Mux.HandleFunc("/user/", func(writer http.ResponseWriter, request *http.Request) {
+		s.Equal("GET", request.Method, "unexpected http method called for GetUser")
+		respUser := user.User{
+			ID: expectedUserId,
+		}
+		respBody, err := json.Marshal(respUser)
+		if s.NoError(err) {
+			writer.Write(respBody)
+		}
+	})
 
-	client := NewClient(APIParams{}, "")
+	user, err := s.TestService.GetUser(context.Background())
+	if s.NoError(err) {
+		s.Equal(expectedUserId, user.ID, "UserID must match.")
+	}
 
-	testUserService := client.User
+}
 
-	user, _ := testUserService.GetUser(context.Background())
-
-	assert.Equal(t, "1234", user.ID, "UserID must match.")
-
+func TestUserServiceSuite(t *testing.T) {
+	suite.Run(t, new(UserServiceTestSuite))
 }

--- a/pkg/pennsieve/user_test.go
+++ b/pkg/pennsieve/user_test.go
@@ -21,7 +21,7 @@ func (s *UserServiceTestSuite) SetupTest() {
 	s.MockPennsieveServer = NewMockPennsieveServerDefault(s.T())
 	client := NewClient(APIParams{
 		ApiHost: s.Server.URL,
-	}, s.IdProviderServer.URL)
+	}, &AWSCognitoEndpoints{IdentityProviderEndpoint: s.IdProviderServer.URL})
 	s.TestService = client.User
 }
 
@@ -40,13 +40,14 @@ func (s *UserServiceTestSuite) TestGetUser() {
 		}
 		respBody, err := json.Marshal(respUser)
 		if s.NoError(err) {
-			writer.Write(respBody)
+			_, err = writer.Write(respBody)
+			s.NoError(err)
 		}
 	})
 
-	user, err := s.TestService.GetUser(context.Background())
+	userResp, err := s.TestService.GetUser(context.Background())
 	if s.NoError(err) {
-		s.Equal(expectedUserId, user.ID, "UserID must match.")
+		s.Equal(expectedUserId, userResp.ID, "UserID must match.")
 	}
 
 }


### PR DESCRIPTION
This PR allows for the configuration of custom endpoints for Cognito. 

The current use case for this is in tests. With this PR we can point `AuthenticationService`, and thus the Pennsieve `Client`, at a local `httptest.Server` instead of actual AWS servers. Using mock external servers rather than mock client-side code should allow us to write more comprehensive tests since we won't be replacing real client code with mocks.

The PR also includes several new tests that make use of this change.

Also fixes a typo that would cause `OrganizationService.List()` to fail.