### PR TITLE
Fix Backwards Compatibility

### DIFF
--- a/pkg/pennsieve/authentication_test.go
+++ b/pkg/pennsieve/authentication_test.go
@@ -49,15 +49,16 @@ func (s *AuthenticationServiceTestSuite) SetupTest() {
 		Mux:    cognitoMux,
 	}
 	s.MockPennsieveServer = NewMockPennsieveServer(s.T(), expectedCognitoConfig)
+	AWSEndpoints = AWSCognitoEndpoints{IdentityProviderEndpoint: s.MockCognito.Server.URL}
 	s.TestClient = NewClient(
-		APIParams{ApiHost: s.Server.URL},
-		&AWSCognitoEndpoints{IdentityProviderEndpoint: s.MockCognito.Server.URL})
+		APIParams{ApiHost: s.Server.URL})
 	s.TestService = s.TestClient.Authentication
 }
 
 func (s *AuthenticationServiceTestSuite) TearDownTest() {
 	s.MockCognito.Close()
 	s.MockPennsieveServer.Close()
+	AWSEndpoints.Reset()
 }
 
 func (s *AuthenticationServiceTestSuite) TestGetCognitoConfig() {
@@ -124,7 +125,7 @@ func TestAuthenticationServiceSuite(t *testing.T) {
 // endpoint resolver for AWS
 func TestProdEndpointResolver(t *testing.T) {
 	client := noOpPennsieveClient{}
-	service := NewAuthenticationService(client, "https://example.com", nil)
+	service := NewAuthenticationService(client, "https://example.com")
 	//goland:noinspection GoDeprecation
 	assert.Nil(t, (*service).awsConfig.EndpointResolver)
 	assert.Nil(t, (*service).awsConfig.EndpointResolverWithOptions)

--- a/pkg/pennsieve/client.go
+++ b/pkg/pennsieve/client.go
@@ -56,7 +56,7 @@ type Client struct {
 }
 
 // NewClient creates a new Pennsieve HTTP client.
-func NewClient(params APIParams, awsCognitoEndpoints *AWSCognitoEndpoints) *Client {
+func NewClient(params APIParams) *Client {
 
 	c := &Client{
 		APISession:         APISession{},
@@ -66,7 +66,7 @@ func NewClient(params APIParams, awsCognitoEndpoints *AWSCognitoEndpoints) *Clie
 		OrganizationId:     0,
 	}
 
-	c.Authentication = NewAuthenticationService(c, params.ApiHost, awsCognitoEndpoints)
+	c.Authentication = NewAuthenticationService(c, params.ApiHost)
 	c.Organization = NewOrganizationService(c, params.ApiHost)
 	c.User = NewUserService(c, params.ApiHost)
 	c.Dataset = NewDatasetService(c, params.ApiHost)

--- a/pkg/pennsieve/client_test.go
+++ b/pkg/pennsieve/client_test.go
@@ -21,14 +21,15 @@ type ClientTestSuite struct {
 func (s *ClientTestSuite) SetupTest() {
 	s.MockCognitoServer = NewMockCognitoServerDefault(s.T())
 	s.MockPennsieveServer = NewMockPennsieveServerDefault(s.T())
+	AWSEndpoints = AWSCognitoEndpoints{IdentityProviderEndpoint: s.IdProviderServer.URL}
 	s.TestClient = NewClient(
-		APIParams{ApiHost: s.Server.URL},
-		&AWSCognitoEndpoints{IdentityProviderEndpoint: s.IdProviderServer.URL})
+		APIParams{ApiHost: s.Server.URL})
 }
 
 func (s *ClientTestSuite) TearDownTest() {
 	s.MockCognitoServer.Close()
 	s.MockPennsieveServer.Close()
+	AWSEndpoints.Reset()
 }
 
 type requestBody struct {

--- a/pkg/pennsieve/dataset_test.go
+++ b/pkg/pennsieve/dataset_test.go
@@ -20,15 +20,17 @@ type DatasetServiceTestSuite struct {
 func (s *DatasetServiceTestSuite) SetupTest() {
 	s.MockCognitoServer = NewMockCognitoServerDefault(s.T())
 	s.MockPennsieveServer = NewMockPennsieveServerDefault(s.T())
+	AWSEndpoints = AWSCognitoEndpoints{IdentityProviderEndpoint: s.IdProviderServer.URL}
 	client := NewClient(APIParams{
 		ApiHost: s.Server.URL,
-	}, &AWSCognitoEndpoints{IdentityProviderEndpoint: s.IdProviderServer.URL})
+	})
 	s.TestService = client.Dataset
 }
 
 func (s *DatasetServiceTestSuite) TearDownTest() {
 	s.MockPennsieveServer.Close()
 	s.MockCognitoServer.Close()
+	AWSEndpoints.Reset()
 }
 
 func (s *DatasetServiceTestSuite) TestGetDataset() {

--- a/pkg/pennsieve/manifest_test.go
+++ b/pkg/pennsieve/manifest_test.go
@@ -22,10 +22,11 @@ func (s *ManifestServiceTestSuite) SetupTest() {
 	s.MockCognitoServer = NewMockCognitoServerDefault(s.T())
 	s.APIServer = NewMockPennsieveServerDefault(s.T())
 	s.API2Server = NewMockPennsieveServerDefault(s.T())
+	AWSEndpoints = AWSCognitoEndpoints{IdentityProviderEndpoint: s.IdProviderServer.URL}
 	client := NewClient(APIParams{
 		ApiHost:  s.APIServer.Server.URL,
 		ApiHost2: s.API2Server.Server.URL,
-	}, &AWSCognitoEndpoints{IdentityProviderEndpoint: s.IdProviderServer.URL})
+	})
 	s.TestService = client.Manifest
 }
 
@@ -33,6 +34,7 @@ func (s *ManifestServiceTestSuite) TearDownTest() {
 	s.MockCognitoServer.Close()
 	s.APIServer.Close()
 	s.API2Server.Close()
+	AWSEndpoints.Reset()
 }
 
 func (s *ManifestServiceTestSuite) TestCreateManifest() {

--- a/pkg/pennsieve/organization_test.go
+++ b/pkg/pennsieve/organization_test.go
@@ -19,15 +19,16 @@ type OrganizationServiceTestSuite struct {
 func (s *OrganizationServiceTestSuite) SetupTest() {
 	s.MockCognitoServer = NewMockCognitoServerDefault(s.T())
 	s.MockPennsieveServer = NewMockPennsieveServerDefault(s.T())
+	AWSEndpoints = AWSCognitoEndpoints{IdentityProviderEndpoint: s.IdProviderServer.URL}
 	client := NewClient(
-		APIParams{ApiHost: s.Server.URL},
-		&AWSCognitoEndpoints{IdentityProviderEndpoint: s.IdProviderServer.URL})
+		APIParams{ApiHost: s.Server.URL})
 	s.TestService = client.Organization
 }
 
 func (s *OrganizationServiceTestSuite) TearDownTest() {
 	s.MockCognitoServer.Close()
 	s.MockPennsieveServer.Close()
+	AWSEndpoints.Reset()
 }
 
 // Testing very basic component of UserService to get active user.

--- a/pkg/pennsieve/user_test.go
+++ b/pkg/pennsieve/user_test.go
@@ -19,15 +19,17 @@ type UserServiceTestSuite struct {
 func (s *UserServiceTestSuite) SetupTest() {
 	s.MockCognitoServer = NewMockCognitoServerDefault(s.T())
 	s.MockPennsieveServer = NewMockPennsieveServerDefault(s.T())
+	AWSEndpoints = AWSCognitoEndpoints{IdentityProviderEndpoint: s.IdProviderServer.URL}
 	client := NewClient(APIParams{
 		ApiHost: s.Server.URL,
-	}, &AWSCognitoEndpoints{IdentityProviderEndpoint: s.IdProviderServer.URL})
+	})
 	s.TestService = client.User
 }
 
 func (s *UserServiceTestSuite) TearDownTest() {
 	s.MockCognitoServer.Close()
 	s.MockPennsieveServer.Close()
+	AWSEndpoints.Reset()
 }
 
 // Testing very basic component of UserService to get active user.


### PR DESCRIPTION
PR #3 broke backwards compatibility by adding a configuration object to the argument list of exported functions. This PR restores compatibility by removing those arguments and using a configuration variable instead.