### PR TITLE
feature: adds call to account service to request ECR access

### DIFF
--- a/pkg/pennsieve/account.go
+++ b/pkg/pennsieve/account.go
@@ -3,6 +3,7 @@ package pennsieve
 import (
     "bytes"
     "context"
+    "encoding/json"
     "fmt"
     "log"
     "net/http"
@@ -122,15 +123,15 @@ func (a *accountService) DeleteAccount(ctx context.Context, uuid string, force b
 }
 
 func (a *accountService) RequestEcrAccess(ctx context.Context, accountId string, accountType string) error {
-    postParams := fmt.Sprintf(`
-		{
-			"accountId": "%s",
-			"accountType": "%s"
-		}`, accountId, accountType)
+    body, err := json.Marshal(struct {
+        AccountId   string `json:"accountId"`
+        AccountType string `json:"accountType"`
+    }{accountId, accountType})
+    if err != nil {
+        return err
+    }
 
-    postParamsPayload := bytes.NewReader([]byte(postParams))
-
-    req, err := http.NewRequest("POST", fmt.Sprintf("%s/compute/resources/app-store/access", a.BaseUrl), postParamsPayload)
+    req, err := http.NewRequest("POST", fmt.Sprintf("%s/compute/resources/app-store/access", a.BaseUrl), bytes.NewReader(body))
     if err != nil {
         return err
     }

--- a/pkg/pennsieve/account.go
+++ b/pkg/pennsieve/account.go
@@ -15,6 +15,7 @@ type AccountService interface {
     CreateAccount(ctx context.Context, accountId string, accountType string, roleName string, externalId string) (*account.CreateAccountResponse, error)
     GetAccounts(ctx context.Context) ([]account.AccountResponse, error)
     DeleteAccount(ctx context.Context, uuid string, force bool) (*account.DeleteAccountResponse, error)
+    RequestEcrAccess(ctx context.Context, accountId string, accountType string) error
     SetBaseUrl(url string)
 }
 
@@ -118,6 +119,32 @@ func (a *accountService) DeleteAccount(ctx context.Context, uuid string, force b
     }
 
     return &res, nil
+}
+
+func (a *accountService) RequestEcrAccess(ctx context.Context, accountId string, accountType string) error {
+    postParams := fmt.Sprintf(`
+		{
+			"accountId": "%s",
+			"accountType": "%s"
+		}`, accountId, accountType)
+
+    postParamsPayload := bytes.NewReader([]byte(postParams))
+
+    req, err := http.NewRequest("POST", fmt.Sprintf("%s/compute/resources/app-store/access", a.BaseUrl), postParamsPayload)
+    if err != nil {
+        return err
+    }
+
+    if ctx == nil {
+        ctx = req.Context()
+    }
+
+    if err := a.Client.sendRequest(ctx, req, nil); err != nil {
+        log.Println("AccountService: SendRequest Error in RequestEcrAccess: ", err)
+        return err
+    }
+
+    return nil
 }
 
 func (s *accountService) SetBaseUrl(url string) {

--- a/pkg/pennsieve/account_test.go
+++ b/pkg/pennsieve/account_test.go
@@ -94,6 +94,30 @@ func (s *AccountServiceTestSuite) TestCreateAccount() {
 	}
 }
 
+func (s *AccountServiceTestSuite) TestRequestEcrAccess() {
+	expectedAccountId := "12345"
+	expectedAccountType := "aws"
+
+	s.API2Server.Mux.HandleFunc("/compute/resources/app-store/access", func(writer http.ResponseWriter, request *http.Request) {
+		s.Equalf("POST", request.Method, "expected method POST, got: %q", request.Method)
+		requestBody := struct {
+			AccountId   string `json:"accountId"`
+			AccountType string `json:"accountType"`
+		}{}
+		data, _ := io.ReadAll(request.Body)
+		err := json.Unmarshal(data, &requestBody)
+		if err != nil {
+			s.Fail("error decoding request body", err)
+		}
+		s.Equal(expectedAccountId, requestBody.AccountId, "unexpected accountId in request body")
+		s.Equal(expectedAccountType, requestBody.AccountType, "unexpected accountType in request body")
+		writer.WriteHeader(http.StatusOK)
+	})
+
+	err := s.TestService.RequestEcrAccess(context.Background(), expectedAccountId, expectedAccountType)
+	s.NoError(err)
+}
+
 func TestAccountServiceTestSuite(t *testing.T) {
 	suite.Run(t, new(AccountServiceTestSuite))
 }


### PR DESCRIPTION
Related: https://app.clickup.com/t/868hqdh1y (architectural diagram on ticket)

Current changes: App store ECR access

  - Added RequestEcrAccess(ctx, accountId, accountType) error to the AccountService interface
  - Implementation sends a POST to /compute/resources/app-store/access with accountId and accountType
  - Returns only error — the backend attaches an ECR policy to grant the account access to the private ECR repo (no response body)
  - Added test validating the request method, path, and body

