### PR TITLE
Add direct-to-storage client methods and typed HTTPError

### DIFF
--- a/pkg/pennsieve/client.go
+++ b/pkg/pennsieve/client.go
@@ -3,7 +3,6 @@ package pennsieve
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"log"
 	"net/http"
@@ -38,6 +37,21 @@ type APIParams struct {
 type errorResponse struct {
 	Code    int    `json:"code"`
 	Message string `json:"message"`
+}
+
+// HTTPError is returned by sendRequest when the server responds with a non-2xx
+// status. Callers that need to branch on the status (e.g. fall back on 404)
+// can type-assert on errors.As(err, &HTTPError{}).
+type HTTPError struct {
+	StatusCode int
+	Message    string
+}
+
+func (e *HTTPError) Error() string {
+	if e.Message == "" {
+		return fmt.Sprintf("http status %d", e.StatusCode)
+	}
+	return fmt.Sprintf("http status %d: %s", e.StatusCode, e.Message)
 }
 
 type Client struct {
@@ -113,10 +127,10 @@ func (c *Client) sendUnauthenticatedRequest(ctx context.Context, req *http.Reque
 	if res.StatusCode != http.StatusOK {
 		var errRes errorResponse
 		if err = json.NewDecoder(res.Body).Decode(&errRes); err == nil {
-			return errors.New(errRes.Message)
+			return &HTTPError{StatusCode: res.StatusCode, Message: errRes.Message}
 		}
 
-		return fmt.Errorf("unknown error, status code: %d", res.StatusCode)
+		return &HTTPError{StatusCode: res.StatusCode}
 	}
 
 	if err = json.NewDecoder(res.Body).Decode(&v); err != nil {
@@ -167,10 +181,10 @@ func (c *Client) sendRequest(ctx context.Context, req *http.Request, v interface
 	if res.StatusCode != http.StatusOK && res.StatusCode != http.StatusCreated {
 		var errRes errorResponse
 		if err = json.NewDecoder(res.Body).Decode(&errRes); err == nil {
-			return errors.New(errRes.Message)
+			return &HTTPError{StatusCode: res.StatusCode, Message: errRes.Message}
 		}
 
-		return fmt.Errorf("unknown error, status code: %d", res.StatusCode)
+		return &HTTPError{StatusCode: res.StatusCode}
 	}
 
 	if v != nil {

--- a/pkg/pennsieve/manifest.go
+++ b/pkg/pennsieve/manifest.go
@@ -4,18 +4,55 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
-	"github.com/pennsieve/pennsieve-go-core/pkg/models/manifest"
-	"github.com/pennsieve/pennsieve-go-core/pkg/models/manifest/manifestFile"
 	"log"
 	"net/http"
+	"sync"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/pennsieve/pennsieve-go-core/pkg/models/manifest"
+	"github.com/pennsieve/pennsieve-go-core/pkg/models/manifest/manifestFile"
 )
 
 type ManifestService interface {
 	Create(ctx context.Context, requestBody manifest.DTO) (*manifest.PostResponse, error)
 	GetFilesForStatus(ctx context.Context, manifestId string,
 		status manifestFile.Status, continuationToken string, verify bool) (*manifest.GetStatusEndpointResponse, error)
+	GetStorageCredentials(ctx context.Context, datasetId, manifestNodeId string) (*StorageCredentials, error)
+	FinalizeManifestFiles(ctx context.Context, datasetId, manifestNodeId string, files []FinalizeFile) (*FinalizeResponse, error)
 	SetBaseUrl(url string)
+}
+
+// StorageCredentials describes a short-lived STS session scoped to a specific
+// manifest's destination prefix. Returned by POST /manifest/storage-credentials.
+type StorageCredentials struct {
+	AccessKeyID     string    `json:"accessKeyId"`
+	SecretAccessKey string    `json:"secretAccessKey"`
+	SessionToken    string    `json:"sessionToken"`
+	Expiration      time.Time `json:"expiration"`
+	Bucket          string    `json:"bucket"`
+	KeyPrefix       string    `json:"keyPrefix"`
+	Region          string    `json:"region"`
+}
+
+// FinalizeFile is one file in a POST /manifest/files/finalize batch.
+type FinalizeFile struct {
+	UploadID string `json:"uploadId"`
+	Size     int64  `json:"size"`
+	SHA256   string `json:"sha256,omitempty"`
+}
+
+// FinalizeResult is the server's per-file verdict.
+type FinalizeResult struct {
+	UploadID string `json:"uploadId"`
+	Status   string `json:"status"` // "finalized" | "failed"
+	Error    string `json:"error,omitempty"`
+}
+
+type FinalizeResponse struct {
+	Results []FinalizeResult `json:"results"`
 }
 
 type manifestService struct {
@@ -86,4 +123,190 @@ func (s *manifestService) GetFilesForStatus(ctx context.Context, manifestId stri
 
 func (s *manifestService) SetBaseUrl(url string) {
 	s.baseUrl = url
+}
+
+// GetStorageCredentials requests STS credentials scoped to the manifest's
+// destination storage bucket + O{org}/D{ds}/{manifest}/* prefix. The caller
+// can treat HTTPError{StatusCode=404} as "endpoint not yet deployed" and fall
+// back to the legacy Cognito + upload-bucket path.
+func (s *manifestService) GetStorageCredentials(ctx context.Context, datasetId, manifestNodeId string) (*StorageCredentials, error) {
+	requestStr := fmt.Sprintf("%s/manifest/storage-credentials?dataset_id=%s", s.baseUrl, datasetId)
+
+	body, _ := json.Marshal(map[string]string{"manifestNodeId": manifestNodeId})
+	req, err := http.NewRequest("POST", requestStr, bytes.NewBuffer(body))
+	if err != nil {
+		return nil, err
+	}
+	if ctx == nil {
+		ctx = req.Context()
+	}
+
+	res := StorageCredentials{}
+	if err := s.client.sendRequest(ctx, req, &res); err != nil {
+		return nil, err
+	}
+	return &res, nil
+}
+
+// FinalizeManifestFiles reports a batch of files the agent has successfully
+// uploaded direct-to-storage. The server verifies each object, creates
+// Postgres package/file rows, and returns per-file results. Idempotent.
+// Max batch size is 500 on the server — callers must split larger lists.
+func (s *manifestService) FinalizeManifestFiles(ctx context.Context, datasetId, manifestNodeId string, files []FinalizeFile) (*FinalizeResponse, error) {
+	requestStr := fmt.Sprintf("%s/manifest/files/finalize?dataset_id=%s", s.baseUrl, datasetId)
+
+	body, err := json.Marshal(struct {
+		ManifestNodeID string         `json:"manifestNodeId"`
+		Files          []FinalizeFile `json:"files"`
+	}{manifestNodeId, files})
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest("POST", requestStr, bytes.NewBuffer(body))
+	if err != nil {
+		return nil, err
+	}
+	if ctx == nil {
+		ctx = req.Context()
+	}
+
+	res := FinalizeResponse{}
+	if err := s.client.sendRequest(ctx, req, &res); err != nil {
+		return nil, err
+	}
+	return &res, nil
+}
+
+// StorageCredentialsProvider implements aws.CredentialsProvider by fetching
+// STS credentials from the Pennsieve storage-credentials endpoint and
+// refreshing before they expire. Thread-safe. One provider per
+// (manifestNodeId, datasetId) pair.
+//
+// Concurrency: many S3 workers can call Retrieve simultaneously around the
+// refresh boundary. A refresh mutex ensures only one in-flight HTTP refresh;
+// others park briefly and pick up the refreshed cache.
+//
+// Transient errors (network blips, 5xx) are retried with exponential backoff
+// so a single upload-service glitch doesn't kill an in-flight upload.
+// Permanent errors (4xx) are returned immediately — the caller (agent) can
+// fall back to the legacy path.
+type StorageCredentialsProvider struct {
+	Manifest       ManifestService
+	DatasetID      string
+	ManifestNodeID string
+
+	mu        sync.Mutex // guards cache read/write
+	cache     *StorageCredentials
+	refreshMu sync.Mutex // single-flight guard for concurrent refreshes
+}
+
+const (
+	credsExpiryWindow  = 5 * time.Minute
+	credsFetchAttempts = 3
+	credsFetchBaseWait = 200 * time.Millisecond
+)
+
+// Retrieve returns cached credentials if still valid; otherwise refreshes
+// from the API. Safe for concurrent use — only one refresh runs at a time.
+func (p *StorageCredentialsProvider) Retrieve(ctx context.Context) (aws.Credentials, error) {
+	// Fast path: valid cached creds.
+	if creds, ok := p.cachedIfValid(); ok {
+		return creds, nil
+	}
+
+	// Slow path: single-flight refresh. While we hold refreshMu, concurrent
+	// callers queue behind us; after we finish, they re-check the cache and
+	// skip the network call.
+	p.refreshMu.Lock()
+	defer p.refreshMu.Unlock()
+
+	if creds, ok := p.cachedIfValid(); ok {
+		return creds, nil
+	}
+
+	c, err := p.fetchWithRetry(ctx)
+	if err != nil {
+		return aws.Credentials{}, err
+	}
+
+	p.mu.Lock()
+	p.cache = c
+	p.mu.Unlock()
+
+	return toAWSCreds(c), nil
+}
+
+// cachedIfValid returns cached credentials if they have more than the expiry
+// window left before expiration.
+func (p *StorageCredentialsProvider) cachedIfValid() (aws.Credentials, bool) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.cache != nil && time.Until(p.cache.Expiration) > credsExpiryWindow {
+		return toAWSCreds(p.cache), true
+	}
+	return aws.Credentials{}, false
+}
+
+// fetchWithRetry calls GetStorageCredentials with exponential backoff on
+// transient errors. 4xx responses (permanent — auth, not-found, wrong
+// dataset) are returned immediately so the caller can fall back.
+func (p *StorageCredentialsProvider) fetchWithRetry(ctx context.Context) (*StorageCredentials, error) {
+	var lastErr error
+	for attempt := 0; attempt < credsFetchAttempts; attempt++ {
+		c, err := p.Manifest.GetStorageCredentials(ctx, p.DatasetID, p.ManifestNodeID)
+		if err == nil {
+			return c, nil
+		}
+		lastErr = err
+
+		// Don't retry permanent errors.
+		var httpErr *HTTPError
+		if errors.As(err, &httpErr) && httpErr.StatusCode >= 400 && httpErr.StatusCode < 500 {
+			return nil, err
+		}
+
+		if attempt == credsFetchAttempts-1 {
+			break
+		}
+		delay := credsFetchBaseWait * time.Duration(1<<attempt)
+		select {
+		case <-time.After(delay):
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		}
+	}
+	return nil, lastErr
+}
+
+// BucketAndPrefix returns the last-fetched bucket and key-prefix, if any.
+// Callers should call Retrieve at least once first.
+func (p *StorageCredentialsProvider) BucketAndPrefix() (bucket, keyPrefix string) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.cache == nil {
+		return "", ""
+	}
+	return p.cache.Bucket, p.cache.KeyPrefix
+}
+
+// Region returns the last-fetched region. Zero value if no successful fetch yet.
+func (p *StorageCredentialsProvider) Region() string {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	if p.cache == nil {
+		return ""
+	}
+	return p.cache.Region
+}
+
+func toAWSCreds(c *StorageCredentials) aws.Credentials {
+	return aws.Credentials{
+		AccessKeyID:     c.AccessKeyID,
+		SecretAccessKey: c.SecretAccessKey,
+		SessionToken:    c.SessionToken,
+		Source:          "PennsieveStorageCredentials",
+		CanExpire:       true,
+		Expires:         c.Expiration,
+	}
 }

--- a/pkg/pennsieve/storage_credentials_test.go
+++ b/pkg/pennsieve/storage_credentials_test.go
@@ -1,0 +1,156 @@
+package pennsieve
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/pennsieve/pennsieve-go-core/pkg/models/manifest"
+	"github.com/pennsieve/pennsieve-go-core/pkg/models/manifest/manifestFile"
+	"github.com/stretchr/testify/assert"
+)
+
+type fakeManifest struct {
+	calls       atomic.Int32
+	err         error
+	transient   int32 // first N calls fail transiently, then succeed
+	transientEr error
+	creds       StorageCredentials
+}
+
+func (f *fakeManifest) Create(ctx context.Context, _ manifest.DTO) (*manifest.PostResponse, error) {
+	return nil, nil
+}
+func (f *fakeManifest) GetFilesForStatus(_ context.Context, _ string, _ manifestFile.Status, _ string, _ bool) (*manifest.GetStatusEndpointResponse, error) {
+	return nil, nil
+}
+func (f *fakeManifest) SetBaseUrl(_ string) {}
+func (f *fakeManifest) FinalizeManifestFiles(_ context.Context, _, _ string, _ []FinalizeFile) (*FinalizeResponse, error) {
+	return nil, nil
+}
+func (f *fakeManifest) GetStorageCredentials(_ context.Context, _, _ string) (*StorageCredentials, error) {
+	n := f.calls.Add(1)
+	if n <= f.transient && f.transientEr != nil {
+		return nil, f.transientEr
+	}
+	if f.err != nil {
+		return nil, f.err
+	}
+	c := f.creds
+	return &c, nil
+}
+
+func TestStorageCredsProvider_CachesValidCreds(t *testing.T) {
+	fm := &fakeManifest{creds: StorageCredentials{
+		AccessKeyID: "AK", SecretAccessKey: "SK", SessionToken: "ST",
+		Expiration: time.Now().Add(1 * time.Hour),
+		Bucket:     "b", KeyPrefix: "O1/D2/m", Region: "us-east-1",
+	}}
+	p := &StorageCredentialsProvider{Manifest: fm}
+
+	for i := 0; i < 5; i++ {
+		_, err := p.Retrieve(context.Background())
+		assert.NoError(t, err)
+	}
+	assert.Equal(t, int32(1), fm.calls.Load(), "should cache — only first call fetches")
+}
+
+func TestStorageCredsProvider_RefreshesNearExpiry(t *testing.T) {
+	fm := &fakeManifest{creds: StorageCredentials{
+		Expiration: time.Now().Add(2 * time.Minute), // within 5-min window
+		Region:     "us-east-1",
+	}}
+	p := &StorageCredentialsProvider{Manifest: fm}
+
+	_, _ = p.Retrieve(context.Background())
+	_, _ = p.Retrieve(context.Background())
+	assert.Equal(t, int32(2), fm.calls.Load(), "should refetch because cached creds are within expiry window")
+}
+
+func TestStorageCredsProvider_SingleFlight(t *testing.T) {
+	// Block the fake so we can observe multiple goroutines piling up.
+	release := make(chan struct{})
+	var started atomic.Int32
+	fm := &fakeManifest{creds: StorageCredentials{
+		Expiration: time.Now().Add(1 * time.Hour),
+		Region:     "us-east-1",
+	}}
+	// Wrap to add a block.
+	blocking := &blockingManifest{inner: fm, started: &started, release: release}
+	p := &StorageCredentialsProvider{Manifest: blocking}
+
+	const n = 10
+	var wg sync.WaitGroup
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, _ = p.Retrieve(context.Background())
+		}()
+	}
+
+	// Wait until the first Retrieve has started its network call.
+	for started.Load() == 0 {
+		time.Sleep(time.Millisecond)
+	}
+	close(release)
+	wg.Wait()
+
+	assert.Equal(t, int32(1), fm.calls.Load(), "single-flight should collapse concurrent refreshes to one")
+}
+
+type blockingManifest struct {
+	inner   *fakeManifest
+	started *atomic.Int32
+	release chan struct{}
+}
+
+func (b *blockingManifest) Create(ctx context.Context, d manifest.DTO) (*manifest.PostResponse, error) {
+	return b.inner.Create(ctx, d)
+}
+func (b *blockingManifest) GetFilesForStatus(ctx context.Context, id string, s manifestFile.Status, ct string, v bool) (*manifest.GetStatusEndpointResponse, error) {
+	return b.inner.GetFilesForStatus(ctx, id, s, ct, v)
+}
+func (b *blockingManifest) SetBaseUrl(u string) { b.inner.SetBaseUrl(u) }
+func (b *blockingManifest) FinalizeManifestFiles(ctx context.Context, d, m string, f []FinalizeFile) (*FinalizeResponse, error) {
+	return b.inner.FinalizeManifestFiles(ctx, d, m, f)
+}
+func (b *blockingManifest) GetStorageCredentials(ctx context.Context, d, m string) (*StorageCredentials, error) {
+	b.started.Add(1)
+	<-b.release
+	return b.inner.GetStorageCredentials(ctx, d, m)
+}
+
+func TestStorageCredsProvider_RetriesTransient(t *testing.T) {
+	fm := &fakeManifest{
+		transient:   2, // first 2 calls fail with 5xx
+		transientEr: &HTTPError{StatusCode: 503, Message: "unavailable"},
+		creds: StorageCredentials{
+			Expiration: time.Now().Add(1 * time.Hour),
+			Region:     "us-east-1",
+		},
+	}
+	p := &StorageCredentialsProvider{Manifest: fm}
+
+	_, err := p.Retrieve(context.Background())
+	assert.NoError(t, err, "should succeed on 3rd attempt")
+	assert.Equal(t, int32(3), fm.calls.Load())
+}
+
+func TestStorageCredsProvider_DoesNotRetry4xx(t *testing.T) {
+	fm := &fakeManifest{
+		transient:   5,
+		transientEr: &HTTPError{StatusCode: 404, Message: "not found"},
+	}
+	p := &StorageCredentialsProvider{Manifest: fm}
+
+	_, err := p.Retrieve(context.Background())
+	assert.Error(t, err)
+	var httpErr *HTTPError
+	assert.True(t, errors.As(err, &httpErr))
+	assert.Equal(t, 404, httpErr.StatusCode)
+	assert.Equal(t, int32(1), fm.calls.Load(), "permanent errors should not be retried")
+}


### PR DESCRIPTION
Adds ManifestService.GetStorageCredentials and FinalizeManifestFiles for the upload-service-v2 two-phase direct-to-storage upload flow, plus a StorageCredentialsProvider that implements aws.CredentialsProvider with retry/backoff and single-flight refresh.

sendRequest now returns a typed *HTTPError on non-2xx responses so callers can branch on status (e.g. fall back on 404 when hitting an older upload-service deployment without the new endpoints).