### PR TITLE
Add onConflict option to FinalizeManifestFiles

### DIFF
--- a/pkg/pennsieve/manifest.go
+++ b/pkg/pennsieve/manifest.go
@@ -21,8 +21,36 @@ type ManifestService interface {
 	GetFilesForStatus(ctx context.Context, manifestId string,
 		status manifestFile.Status, continuationToken string, verify bool) (*manifest.GetStatusEndpointResponse, error)
 	GetStorageCredentials(ctx context.Context, datasetId, manifestNodeId string) (*StorageCredentials, error)
-	FinalizeManifestFiles(ctx context.Context, datasetId, manifestNodeId string, files []FinalizeFile) (*FinalizeResponse, error)
+	FinalizeManifestFiles(ctx context.Context, datasetId, manifestNodeId string, files []FinalizeFile, opts ...FinalizeOption) (*FinalizeResponse, error)
 	SetBaseUrl(url string)
+}
+
+// FinalizeOption configures a FinalizeManifestFiles call. Use the provided
+// With* helpers (e.g. WithOnConflict) to set values. Unknown options are
+// forward-compatible: older SDK versions ignore any options they do not
+// recognize, so servers can add new finalize fields without breaking
+// existing clients.
+type FinalizeOption func(*finalizeOptions)
+
+type finalizeOptions struct {
+	onConflict string
+}
+
+// FinalizeOnConflict values accepted by the server. Keep in sync with the
+// validOnConflict switch in upload-service-v2's finalize_files.go.
+const (
+	FinalizeOnConflictKeepBoth = "keepBoth"
+	FinalizeOnConflictReplace  = "replace"
+	FinalizeOnConflictFail     = "fail"
+)
+
+// WithOnConflict tells the server how to resolve name collisions between
+// incoming uploads and existing non-deleted packages under the same
+// (dataset, folder) tuple. Default (when omitted) is keepBoth — append
+// " (N)" to the new upload's name, preserving the existing package.
+// Only applies to file packages; folders always get-or-create by name.
+func WithOnConflict(v string) FinalizeOption {
+	return func(o *finalizeOptions) { o.onConflict = v }
 }
 
 // StorageCredentials describes a short-lived STS session scoped to a specific
@@ -152,13 +180,23 @@ func (s *manifestService) GetStorageCredentials(ctx context.Context, datasetId, 
 // uploaded direct-to-storage. The server verifies each object, creates
 // Postgres package/file rows, and returns per-file results. Idempotent.
 // Max batch size is 500 on the server — callers must split larger lists.
-func (s *manifestService) FinalizeManifestFiles(ctx context.Context, datasetId, manifestNodeId string, files []FinalizeFile) (*FinalizeResponse, error) {
+//
+// Optional FinalizeOptions (e.g. WithOnConflict) tune server-side behavior
+// for the batch. Omitting options preserves legacy behavior: name collisions
+// auto-rename the new upload to " (N)".
+func (s *manifestService) FinalizeManifestFiles(ctx context.Context, datasetId, manifestNodeId string, files []FinalizeFile, opts ...FinalizeOption) (*FinalizeResponse, error) {
+	var o finalizeOptions
+	for _, fn := range opts {
+		fn(&o)
+	}
+
 	requestStr := fmt.Sprintf("%s/upload/manifest/files/finalize?dataset_id=%s", s.baseUrl, datasetId)
 
 	body, err := json.Marshal(struct {
 		ManifestNodeID string         `json:"manifestNodeId"`
 		Files          []FinalizeFile `json:"files"`
-	}{manifestNodeId, files})
+		OnConflict     string         `json:"onConflict,omitempty"`
+	}{manifestNodeId, files, o.onConflict})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/pennsieve/manifest_finalize_test.go
+++ b/pkg/pennsieve/manifest_finalize_test.go
@@ -1,0 +1,100 @@
+package pennsieve
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/suite"
+)
+
+type FinalizeManifestFilesTestSuite struct {
+	suite.Suite
+	MockCognitoServer
+	APIServer   MockPennsieveServer
+	API2Server  MockPennsieveServer
+	TestService ManifestService
+}
+
+func (s *FinalizeManifestFilesTestSuite) SetupTest() {
+	s.MockCognitoServer = NewMockCognitoServerDefault(s.T())
+	s.APIServer = NewMockPennsieveServerDefault(s.T())
+	s.API2Server = NewMockPennsieveServerDefault(s.T())
+	AWSEndpoints = AWSCognitoEndpoints{IdentityProviderEndpoint: s.IdProviderServer.URL}
+	client := NewClient(APIParams{
+		ApiHost:  s.APIServer.Server.URL,
+		ApiHost2: s.API2Server.Server.URL,
+	})
+	s.TestService = client.Manifest
+}
+
+func (s *FinalizeManifestFilesTestSuite) TearDownTest() {
+	s.MockCognitoServer.Close()
+	s.APIServer.Close()
+	s.API2Server.Close()
+	AWSEndpoints.Reset()
+}
+
+// TestFinalizeDefaultOmitsOnConflict asserts that the default call (no
+// FinalizeOption) omits the onConflict field from the request body —
+// legacy clients must hit the server with exactly the same bytes they did
+// before this SDK version.
+func (s *FinalizeManifestFilesTestSuite) TestFinalizeDefaultOmitsOnConflict() {
+	s.API2Server.Mux.HandleFunc("/upload/manifest/files/finalize", func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var got map[string]any
+		s.NoError(json.Unmarshal(body, &got))
+		_, present := got["onConflict"]
+		s.False(present, "onConflict must be omitted from the default-call body (omitempty)")
+		w.Write([]byte(`{"results":[]}`))
+	})
+
+	_, err := s.TestService.FinalizeManifestFiles(
+		context.Background(),
+		"N:Dataset:abc",
+		"N:Manifest:m1",
+		[]FinalizeFile{{UploadID: "u1", Size: 10, SHA256: "sha"}},
+	)
+	s.NoError(err)
+}
+
+// TestFinalizeWithOnConflict asserts that WithOnConflict propagates into
+// the JSON body so the upload-service-v2 finalize handler can consume it.
+func (s *FinalizeManifestFilesTestSuite) TestFinalizeWithOnConflict() {
+	s.API2Server.Mux.HandleFunc("/upload/manifest/files/finalize", func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var got struct {
+			ManifestNodeID string `json:"manifestNodeId"`
+			OnConflict     string `json:"onConflict"`
+		}
+		s.NoError(json.Unmarshal(body, &got))
+		s.Equal("N:Manifest:m1", got.ManifestNodeID)
+		s.Equal(FinalizeOnConflictReplace, got.OnConflict, "WithOnConflict must populate the body field")
+		w.Write([]byte(`{"results":[]}`))
+	})
+
+	_, err := s.TestService.FinalizeManifestFiles(
+		context.Background(),
+		"N:Dataset:abc",
+		"N:Manifest:m1",
+		[]FinalizeFile{{UploadID: "u1", Size: 10, SHA256: "sha"}},
+		WithOnConflict(FinalizeOnConflictReplace),
+	)
+	s.NoError(err)
+}
+
+// TestFinalizeOptionConstants assert the constants match the server-side
+// accepted values. If upload-service-v2's validOnConflict switch changes,
+// this should be updated in lockstep.
+func TestFinalizeOptionConstants(t *testing.T) {
+	assert.Equal(t, "keepBoth", FinalizeOnConflictKeepBoth)
+	assert.Equal(t, "replace", FinalizeOnConflictReplace)
+	assert.Equal(t, "fail", FinalizeOnConflictFail)
+}
+
+func TestFinalizeManifestFilesService(t *testing.T) {
+	suite.Run(t, new(FinalizeManifestFilesTestSuite))
+}

--- a/pkg/pennsieve/storage_credentials_test.go
+++ b/pkg/pennsieve/storage_credentials_test.go
@@ -28,7 +28,7 @@ func (f *fakeManifest) GetFilesForStatus(_ context.Context, _ string, _ manifest
 	return nil, nil
 }
 func (f *fakeManifest) SetBaseUrl(_ string) {}
-func (f *fakeManifest) FinalizeManifestFiles(_ context.Context, _, _ string, _ []FinalizeFile) (*FinalizeResponse, error) {
+func (f *fakeManifest) FinalizeManifestFiles(_ context.Context, _, _ string, _ []FinalizeFile, _ ...FinalizeOption) (*FinalizeResponse, error) {
 	return nil, nil
 }
 func (f *fakeManifest) GetStorageCredentials(_ context.Context, _, _ string) (*StorageCredentials, error) {
@@ -115,8 +115,8 @@ func (b *blockingManifest) GetFilesForStatus(ctx context.Context, id string, s m
 	return b.inner.GetFilesForStatus(ctx, id, s, ct, v)
 }
 func (b *blockingManifest) SetBaseUrl(u string) { b.inner.SetBaseUrl(u) }
-func (b *blockingManifest) FinalizeManifestFiles(ctx context.Context, d, m string, f []FinalizeFile) (*FinalizeResponse, error) {
-	return b.inner.FinalizeManifestFiles(ctx, d, m, f)
+func (b *blockingManifest) FinalizeManifestFiles(ctx context.Context, d, m string, f []FinalizeFile, opts ...FinalizeOption) (*FinalizeResponse, error) {
+	return b.inner.FinalizeManifestFiles(ctx, d, m, f, opts...)
 }
 func (b *blockingManifest) GetStorageCredentials(ctx context.Context, d, m string) (*StorageCredentials, error) {
 	b.started.Add(1)


### PR DESCRIPTION
## Summary

Extends `FinalizeManifestFiles` with an optional variadic `FinalizeOption` pattern. First option: `WithOnConflict` — forwarded to upload-service-v2's finalize endpoint to control name-collision resolution (`keepBoth` | `replace` | `fail`).

Companion PR to upload-service-v2#89 (which accepts the new \`onConflict\` field) and pennsieve-go-core v1.16.0 (DB-side AddPackagesWithConflict).

## Backward compatible by design

- Interface method gains `opts ...FinalizeOption` — legacy callers compile unchanged.
- JSON body uses \`omitempty\` on \`onConflict\`, so default calls hit older upload-service-v2 instances with exactly the same bytes.
- Mock implementations in \`storage_credentials_test.go\` updated to the new signature.

## Usage

\`\`\`go
// Legacy behavior (auto-rename on conflict)
client.Manifest.FinalizeManifestFiles(ctx, datasetId, manifestId, files)

// Replace predecessor, soft-delete + back-ref
client.Manifest.FinalizeManifestFiles(ctx, datasetId, manifestId, files,
    pennsieve.WithOnConflict(pennsieve.FinalizeOnConflictReplace))
\`\`\`

## Test plan

- [x] New \`TestFinalizeDefaultOmitsOnConflict\` asserts default call omits the field (legacy compat)
- [x] New \`TestFinalizeWithOnConflict\` asserts the option propagates into the JSON body
- [x] \`TestFinalizeOptionConstants\` pins the string values to match upload-service-v2's validator
- [ ] Release tag cut; pennsieve-agent bumps dependency and wires --on-conflict flag (follow-up)

## Known pre-existing failure

\`TestManifestService/TestCreateManifest\` fails on origin/main locally — the mock expects \`/manifest\` but the recent route-prefix commit uses \`/upload/manifest\`. Not caused by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)