### PR TITLE
Remove FinalizeOnConflictFail constant

### DIFF
--- a/pkg/pennsieve/manifest.go
+++ b/pkg/pennsieve/manifest.go
@@ -41,7 +41,6 @@ type finalizeOptions struct {
 const (
 	FinalizeOnConflictKeepBoth = "keepBoth"
 	FinalizeOnConflictReplace  = "replace"
-	FinalizeOnConflictFail     = "fail"
 )
 
 // WithOnConflict tells the server how to resolve name collisions between

--- a/pkg/pennsieve/manifest_finalize_test.go
+++ b/pkg/pennsieve/manifest_finalize_test.go
@@ -92,7 +92,6 @@ func (s *FinalizeManifestFilesTestSuite) TestFinalizeWithOnConflict() {
 func TestFinalizeOptionConstants(t *testing.T) {
 	assert.Equal(t, "keepBoth", FinalizeOnConflictKeepBoth)
 	assert.Equal(t, "replace", FinalizeOnConflictReplace)
-	assert.Equal(t, "fail", FinalizeOnConflictFail)
 }
 
 func TestFinalizeManifestFilesService(t *testing.T) {


### PR DESCRIPTION
Companion to pennsieve-go-core Fail-removal. Server will reject `fail` in finalize body. Cuts v1.7.0 on merge.